### PR TITLE
Fix tauri-action version (v1 → v0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - run: pnpm install
 
       - name: Build with Tauri
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - run: pnpm install
 
       - name: Build and upload to release
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- `tauri-apps/tauri-action@v1` tag doesn't exist — the latest major version is `v0` (currently `v0.6`)
- Updates both `ci.yml` and `release.yml`

## Test plan
- [ ] CI jobs resolve the action and start building on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)