### PR TITLE
fix: make the macOS global hotkey work (request Accessibility permission)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS code signing + notarization. tauri-action only signs/notarizes
+          # when these are present, so builds still succeed when the secrets are
+          # unset (producing ad-hoc/unsigned artifacts, as before). Add them once
+          # an Apple Developer account is available — no workflow change needed.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # Disable -march=native in whisper.cpp so CI builds run on all x86_64 CPUs
           WHISPER_NATIVE: "OFF"
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ Download the latest release for your platform from the [Releases page](https://g
 - **macOS** — `.dmg` (universal: Intel + Apple Silicon)
 - **Windows** — `.msi` or `.exe`
 
+### macOS Permissions
+
+On macOS the app needs **two permissions** before the hotkey works — it prompts for both
+on first launch:
+
+- **Accessibility** (System Settings ▸ Privacy & Security ▸ Accessibility) — powers the
+  global push-to-talk hotkey *and* auto-paste. Without it the hotkey does nothing.
+- **Microphone** — to record your speech.
+
+Toggle **Speech AI Tool** on in each pane, then **relaunch the app** (the in-app banner
+has a Relaunch button). The hotkey listener is created at startup, so the grant only
+takes effect after a restart.
+
+> **Unsigned builds:** macOS Gatekeeper blocks unsigned apps on first launch — right-click
+> the app → **Open** → **Open**, or run `xattr -cr "/Applications/Speech AI Tool.app"`.
+> Because macOS ties a permission grant to the app's code signature, an unsigned build can
+> lose the grant when it's rebuilt or moved. If the hotkey stops working after an update,
+> reset and re-grant:
+> ```bash
+> tccutil reset Accessibility com.speech-ai-tool.app
+> tccutil reset Microphone com.speech-ai-tool.app
+> ```
+
 ### Building from Source
 
 #### System Dependencies
@@ -107,6 +130,21 @@ pnpm tauri dev
 # Build for production
 pnpm tauri build
 ```
+
+#### macOS code signing & notarization (maintainers)
+
+The release workflow signs and notarizes the macOS build automatically **if** these
+GitHub Actions secrets are set (otherwise it produces unsigned artifacts, as today):
+
+| Secret | Purpose |
+|--------|---------|
+| `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` | base64 of a *Developer ID Application* `.p12` and its password |
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Your Name (TEAMID)` |
+| `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` | Apple ID + app-specific password + team ID, for notarization |
+
+A Developer ID requires the [Apple Developer Program](https://developer.apple.com/programs/)
+($99/yr). This is separate from Tauri's updater signature (`TAURI_SIGNING_PRIVATE_KEY`),
+which is already configured.
 
 ## Configuration
 

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Required under the hardened runtime so the app can capture microphone
+	     audio. The global-hotkey CGEvent tap and enigo auto-paste are gated by
+	     the Accessibility TCC grant (requested at runtime), not by entitlements. -->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Speech AI Tool records audio from your microphone so it can transcribe your speech locally on this device.</string>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,6 +140,46 @@ fn get_current_hotkey(state: tauri::State<'_, AppState>) -> String {
     state.settings.lock().unwrap().hotkey.clone()
 }
 
+// --- macOS permission commands ---
+//
+// On macOS the global hotkey (CGEvent tap) and auto-paste (`enigo`) both require
+// the Accessibility permission. These commands let the UI check/request it. On
+// other platforms they are no-ops that report "granted".
+
+#[tauri::command]
+fn check_accessibility_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos_event_tap::has_accessibility_permission()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+#[tauri::command]
+fn request_accessibility_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos_event_tap::request_accessibility_permission()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+#[tauri::command]
+fn open_accessibility_settings() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            .spawn();
+    }
+}
+
 // --- Settings commands ---
 
 #[tauri::command]
@@ -263,7 +303,24 @@ pub fn run() {
                 }
             }
 
-            // Start the rdev hotkey listener
+            // On macOS the global hotkey + auto-paste need Accessibility permission.
+            // If it's missing, trigger the system prompt and notify the UI (the
+            // Dashboard also re-checks on mount and shows a banner).
+            #[cfg(target_os = "macos")]
+            {
+                use tauri::Emitter;
+                if !macos_event_tap::has_accessibility_permission() {
+                    eprintln!(
+                        "Accessibility permission not granted — the global hotkey and \
+                         auto-paste will not work until it is granted in System Settings \
+                         ▸ Privacy & Security ▸ Accessibility, then the app is relaunched."
+                    );
+                    macos_event_tap::request_accessibility_permission();
+                    let _ = app.handle().emit("permission-required", "accessibility");
+                }
+            }
+
+            // Start the global hotkey listener
             let hotkey_state = hotkey::start_listener(app.handle(), &loaded_settings.hotkey);
 
             app.manage(AppState {
@@ -298,6 +355,9 @@ pub fn run() {
             set_hotkey,
             get_current_hotkey,
             pause_hotkey,
+            check_accessibility_permission,
+            request_accessibility_permission,
+            open_accessibility_settings,
             get_settings,
             save_settings,
             reset_settings,

--- a/src-tauri/src/macos_event_tap.rs
+++ b/src-tauri/src/macos_event_tap.rs
@@ -5,6 +5,7 @@
 //! Services Manager entirely and map keycodes to rdev::Key ourselves.
 
 use std::ffi::c_void;
+use std::thread;
 
 use rdev::{EventType, Key};
 
@@ -29,6 +30,7 @@ extern "C" {
         user_info: *mut c_void,
     ) -> CFMachPortRef;
     fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
+    fn CGEventTapIsEnabled(tap: CFMachPortRef) -> bool;
     fn CGEventGetIntegerValueField(event: CGEventRef, field: u32) -> i64;
     fn CGEventGetFlags(event: CGEventRef) -> u64;
 }
@@ -43,20 +45,45 @@ extern "C" {
     fn CFRunLoopGetCurrent() -> CFRunLoopRef;
     fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
     fn CFRunLoopRun();
+    fn CFDictionaryCreate(
+        allocator: *const c_void,
+        keys: *const *const c_void,
+        values: *const *const c_void,
+        num_values: isize,
+        key_callbacks: *const c_void,
+        value_callbacks: *const c_void,
+    ) -> *const c_void;
+    fn CFRelease(cf: *const c_void);
 
     static kCFRunLoopCommonModes: CFStringRef;
+    static kCFBooleanTrue: *const c_void;
 }
 
-// CGEventTapCreate constants
-const K_CG_SESSION_EVENT_TAP: u32 = 1;
+// `AXIsProcessTrusted*` (Accessibility permission) live in ApplicationServices.
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXIsProcessTrusted() -> bool;
+    fn AXIsProcessTrustedWithOptions(options: *const c_void) -> bool;
+
+    static kAXTrustedCheckOptionPrompt: CFStringRef;
+}
+
+// CGEventTapCreate constants. We use an HID-level tap (earliest point in the
+// event stream) with the *default* option: this requires Accessibility
+// permission (the same permission `enigo` auto-paste needs) rather than the
+// separate Input Monitoring grant a listen-only tap would require. We never
+// modify or swallow events — the callback always returns the event unchanged —
+// so a default tap behaves like a listener here while unifying on one grant.
+const K_CG_HID_EVENT_TAP: u32 = 0;
 const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
-const K_CG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+const K_CG_EVENT_TAP_OPTION_DEFAULT: u32 = 0;
 
 // CGEventType values
 const K_CG_EVENT_KEY_DOWN: u32 = 10;
 const K_CG_EVENT_KEY_UP: u32 = 11;
 const K_CG_EVENT_FLAGS_CHANGED: u32 = 12;
-const K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFFFFFE;
+const K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFF_FFFE;
+const K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = 0xFFFF_FFFF;
 
 // CGEventField for virtual keycode
 const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
@@ -75,6 +102,44 @@ const K_CG_EVENT_FLAG_MASK_COMMAND: u64 = 0x0010_0000;
 struct TapContext<F> {
     callback: F,
     tap: CFMachPortRef,
+}
+
+// ---------------------------------------------------------------------------
+// Permissions (Accessibility / TCC)
+// ---------------------------------------------------------------------------
+
+/// Returns true if the app currently holds macOS Accessibility permission.
+/// This single grant covers both the CGEvent tap (key capture) and `enigo`
+/// auto-paste (synthetic key posting), so it's the only permission to check.
+pub fn has_accessibility_permission() -> bool {
+    unsafe { AXIsProcessTrusted() }
+}
+
+/// Prompt the user to grant Accessibility permission. Shows the system dialog
+/// that deep-links to System Settings ▸ Privacy & Security ▸ Accessibility and
+/// adds the app to that list. Returns the *current* trust state; the grant only
+/// takes effect after the app is relaunched.
+pub fn request_accessibility_permission() -> bool {
+    unsafe {
+        let keys: [*const c_void; 1] = [kAXTrustedCheckOptionPrompt as *const c_void];
+        let values: [*const c_void; 1] = [kCFBooleanTrue];
+        // Null key/value callbacks are correct here: the key is a framework
+        // constant (matched by pointer, the way AX looks it up) and the value is
+        // the immortal `kCFBooleanTrue` singleton, so nothing needs retain/release.
+        let options = CFDictionaryCreate(
+            std::ptr::null(),
+            keys.as_ptr(),
+            values.as_ptr(),
+            1,
+            std::ptr::null(),
+            std::ptr::null(),
+        );
+        let trusted = AXIsProcessTrustedWithOptions(options);
+        if !options.is_null() {
+            CFRelease(options);
+        }
+        trusted
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -97,16 +162,19 @@ where
 
     unsafe {
         let tap = CGEventTapCreate(
-            K_CG_SESSION_EVENT_TAP,
+            K_CG_HID_EVENT_TAP,
             K_CG_HEAD_INSERT_EVENT_TAP,
-            K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+            K_CG_EVENT_TAP_OPTION_DEFAULT,
             mask,
             raw_callback::<F>,
             context as *mut c_void,
         );
 
         if tap.is_null() {
-            eprintln!("Failed to create CGEvent tap — is Accessibility permission granted?");
+            eprintln!(
+                "Failed to create CGEvent tap — grant Accessibility permission \
+                 (System Settings ▸ Privacy & Security ▸ Accessibility) and relaunch."
+            );
             let _ = Box::from_raw(context);
             return;
         }
@@ -118,6 +186,21 @@ where
         let run_loop = CFRunLoopGetCurrent();
         CFRunLoopAddSource(run_loop, source, kCFRunLoopCommonModes);
         CGEventTapEnable(tap, true);
+
+        // Watchdog: macOS can silently disable a tap (notably across sleep/wake),
+        // and the disabled-event callback isn't 100% reliable. Periodically check
+        // and re-enable. The mach port is thread-safe for enable/is-enabled, so we
+        // pass it as an integer to satisfy `Send`.
+        let tap_addr = tap as usize;
+        thread::spawn(move || loop {
+            thread::sleep(std::time::Duration::from_secs(1));
+            unsafe {
+                let tap = tap_addr as CFMachPortRef;
+                if !CGEventTapIsEnabled(tap) {
+                    CGEventTapEnable(tap, true);
+                }
+            }
+        });
 
         CFRunLoopRun(); // blocks forever
     }
@@ -135,8 +218,11 @@ unsafe extern "C" fn raw_callback<F: FnMut(EventType)>(
 ) -> CGEventRef {
     let ctx = &mut *(user_info as *mut TapContext<F>);
 
-    // macOS disables the tap after a timeout — re-enable it.
-    if event_type == K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT {
+    // macOS disables the tap if our callback is too slow (timeout) or after
+    // certain user input / system transitions — re-enable it in both cases.
+    if event_type == K_CG_EVENT_TAP_DISABLED_BY_TIMEOUT
+        || event_type == K_CG_EVENT_TAP_DISABLED_BY_USER_INPUT
+    {
         if !ctx.tap.is_null() {
             CGEventTapEnable(ctx.tap, true);
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "Entitlements.plist",
+      "minimumSystemVersion": "10.15"
+    }
   },
   "plugins": {
     "updater": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import StatusIndicator from "./components/StatusIndicator";
@@ -7,7 +7,13 @@ import HistoryList from "./components/HistoryList";
 import SettingsPage from "./components/SettingsPage";
 import StatusOverlay from "./components/StatusOverlay";
 import { useAppState } from "./hooks/useAppState";
-import { isWhisperModelLoaded } from "./lib/commands";
+import { useTauriEvent } from "./hooks/useTauriEvent";
+import {
+  isWhisperModelLoaded,
+  checkAccessibilityPermission,
+  requestAccessibilityPermission,
+  openAccessibilitySettings,
+} from "./lib/commands";
 
 const isOverlay =
   new URLSearchParams(window.location.search).get("window") === "overlay";
@@ -28,6 +34,7 @@ function Dashboard() {
   const [modelLoaded, setModelLoaded] = useState(true);
   const [update, setUpdate] = useState<Update | null>(null);
   const [updating, setUpdating] = useState(false);
+  const [permissionOk, setPermissionOk] = useState(true);
 
   useEffect(() => {
     isWhisperModelLoaded().then(setModelLoaded).catch(() => setModelLoaded(false));
@@ -36,6 +43,14 @@ function Dashboard() {
   useEffect(() => {
     check().then((u) => setUpdate(u)).catch(console.error);
   }, []);
+
+  useEffect(() => {
+    checkAccessibilityPermission().then(setPermissionOk).catch(() => {});
+  }, []);
+
+  // The backend emits this when it detects the permission is missing at startup.
+  const onPermissionRequired = useCallback(() => setPermissionOk(false), []);
+  useTauriEvent<string>("permission-required", onPermissionRequired);
 
   if (page === "settings") {
     return (
@@ -64,6 +79,46 @@ function Dashboard() {
         </div>
 
         <div className="space-y-6">
+          {!permissionOk && (
+            <div className="bg-error/10 border border-error text-error text-sm rounded-lg px-4 py-3 space-y-2">
+              <p>
+                Accessibility permission is required for the global hotkey and
+                auto-paste to work. Grant it below, then relaunch the app.
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  onClick={async () => {
+                    await requestAccessibilityPermission();
+                    await openAccessibilitySettings();
+                  }}
+                  className="px-3 py-1 bg-error hover:bg-red-700 text-white text-xs rounded transition-colors"
+                >
+                  Grant Access
+                </button>
+                <button
+                  onClick={() => openAccessibilitySettings()}
+                  className="px-3 py-1 bg-surface hover:bg-primary text-text text-xs rounded transition-colors"
+                >
+                  Open Settings
+                </button>
+                <button
+                  onClick={() => relaunch()}
+                  className="px-3 py-1 bg-surface hover:bg-primary text-text text-xs rounded transition-colors"
+                >
+                  Relaunch
+                </button>
+                <button
+                  onClick={() =>
+                    checkAccessibilityPermission().then(setPermissionOk).catch(() => {})
+                  }
+                  className="px-3 py-1 text-text-muted hover:text-text text-xs transition-colors"
+                >
+                  Re-check
+                </button>
+              </div>
+            </div>
+          )}
+
           {update && (
             <div className="bg-blue-900/30 border border-blue-600 text-blue-200 text-sm rounded-lg px-4 py-3 flex items-center justify-between">
               <span>

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -61,6 +61,20 @@ export async function getCurrentHotkey(): Promise<string> {
   return invoke("get_current_hotkey");
 }
 
+// On macOS these gate the global hotkey + auto-paste on the Accessibility
+// permission. On other platforms the backend reports "granted" (no-op).
+export async function checkAccessibilityPermission(): Promise<boolean> {
+  return invoke("check_accessibility_permission");
+}
+
+export async function requestAccessibilityPermission(): Promise<boolean> {
+  return invoke("request_accessibility_permission");
+}
+
+export async function openAccessibilitySettings(): Promise<void> {
+  return invoke("open_accessibility_settings");
+}
+
 export async function getSettings(): Promise<AppSettings> {
   return invoke("get_settings");
 }


### PR DESCRIPTION
## Why

The global push-to-talk hotkey silently does nothing on macOS. Root cause: the CGEvent tap is created but the app **never requests any TCC permission**, so macOS never prompts the user and the tap is returned inert — zero events, no error. Two related gaps compound it: a listen-only tap would also need *Input Monitoring* while `enigo` auto-paste needs *Accessibility*, and there's no app-bundle hardening/signing, so even a granted permission wouldn't persist across rebuilds.

## What changed

**Permission flow (the actual fix)**
- Request **Accessibility** at startup via `AXIsProcessTrusted` / `AXIsProcessTrustedWithOptions`, and expose `check_accessibility_permission`, `request_accessibility_permission`, `open_accessibility_settings` commands.
- Unify on a single grant: the tap now uses an **HID-level, default-option** tap (returns events unchanged, so keystrokes still pass through). A default tap is gated on **Accessibility** — the same permission `enigo` auto-paste needs — so one prompt covers both.

**Tap robustness**
- Handle both `kCGEventTapDisabledByTimeout` **and** `kCGEventTapDisabledByUserInput`.
- Add a 1s **watchdog** (`CGEventTapIsEnabled` → re-enable) to survive sleep/wake, which the disabled-event callback can miss.
- Corrected the misleading "Accessibility vs Input Monitoring" error message.

**Frontend**
- A banner appears when the permission is missing, with Grant Access / Open Settings / Relaunch / Re-check.

**Bundle + release hardening**
- New `Info.plist` (`NSMicrophoneUsageDescription`) and `Entitlements.plist` (`audio-input`); `bundle.macOS` config in `tauri.conf.json`.
- Secret-gated Apple signing/notarization env in `release.yml` (builds still succeed unsigned when secrets are absent — nothing to change until an Apple Developer account exists).
- README: macOS permissions + signing docs.

## Verification

- ✅ Frontend `tsc --noEmit` passes locally.
- ⚠️ The Rust backend could **not** be compiled locally (no Rust toolchain on the dev box, and the code is `#[cfg(target_os = "macos")]` so only a macOS build exercises it). **Relying on the CI `macos-latest` job to compile-check this.**
- ⏳ End-to-end runtime test (hold hotkey → record → transcribe → auto-paste, and sleep/wake) still needs to be run on a real Mac — see the manual checklist below.

### Manual test on macOS
1. `pnpm install && pnpm tauri build`, open the `.app`.
2. Grant **Accessibility** + **Microphone** when prompted, then **relaunch**.
3. Hold `Cmd+Shift+Space`: expect start tone + tray "recording"; release: transcribes and auto-pastes into the focused app.
4. Sleep/wake the Mac, retry — watchdog should keep the tap alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)