### PR TITLE
fix: remove blank Apple signing env vars from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,16 +80,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # macOS code signing + notarization. tauri-action only signs/notarizes
-          # when these are present, so builds still succeed when the secrets are
-          # unset (producing ad-hoc/unsigned artifacts, as before). Add them once
-          # an Apple Developer account is available — no workflow change needed.
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS code signing + notarization: add APPLE_CERTIFICATE,
+          # APPLE_CERTIFICATE_PASSWORD, APPLE_SIGNING_IDENTITY, APPLE_ID,
+          # APPLE_PASSWORD, APPLE_TEAM_ID secrets once an Apple Developer account
+          # is available. Do NOT add them as empty values — tauri-action will
+          # attempt to import the certificate and fail if the value is blank.
           # Disable -march=native in whisper.cpp so CI builds run on all x86_64 CPUs
           WHISPER_NATIVE: "OFF"
 


### PR DESCRIPTION
Fixes the macOS build failure in v0.3.3 release. tauri-action fails when APPLE_CERTIFICATE is passed as an empty string (unset secret). Removes them entirely — they'll be added back with real values when an Apple Developer account is available.