### PR TITLE
fix: macOS mic permission deadlock loop and stale Accessibility banner

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,3 +39,7 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"
 gdk = "0.18"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+block2 = "0.6"

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -54,7 +54,7 @@ pub fn ensure_listener(app: &AppHandle, state: &Arc<HotkeyState>) {
     thread::spawn(move || {
         let mut held_keys: HashSet<Key> = HashSet::new();
 
-        let mut handle_event = move |event_type: EventType| match event_type {
+        let handle_event = move |event_type: EventType| match event_type {
             EventType::KeyPress(key) => {
                 held_keys.insert(key);
                 check_combo(&held_keys, &state_clone, &app_handle);

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -18,6 +18,8 @@ pub struct HotkeyState {
     combo_active: AtomicBool,
     /// Paused during UI hotkey recording to prevent conflicts
     paused: AtomicBool,
+    /// Whether a listener thread is currently alive
+    listener_running: AtomicBool,
 }
 
 impl HotkeyState {
@@ -26,19 +28,27 @@ impl HotkeyState {
             combo: Mutex::new(combo),
             combo_active: AtomicBool::new(false),
             paused: AtomicBool::new(false),
+            listener_running: AtomicBool::new(false),
         }
     }
 }
 
-/// Start the global key-event listener thread. Returns shared state for runtime updates.
+/// Spawn the global key-event listener thread if one isn't already running.
+/// Idempotent, and restartable: on macOS the CGEvent tap fails to create
+/// while the Accessibility permission is missing, in which case the thread
+/// exits and clears the running flag so a later call can retry (e.g. after
+/// the user grants the permission — no app relaunch needed).
 ///
 /// On macOS we use a direct CGEvent tap (see `macos_event_tap`) to avoid
 /// rdev's `TSMGetInputSourceProperty` call, which crashes on macOS 26.3+
 /// when invoked from a background thread.  On other platforms we use `rdev::listen`.
-pub fn start_listener(app: &AppHandle, hotkey_str: &str) -> Arc<HotkeyState> {
-    let combo = parse_hotkey_string(hotkey_str);
-    let state = Arc::new(HotkeyState::new(combo));
-    let state_clone = Arc::clone(&state);
+pub fn ensure_listener(app: &AppHandle, state: &Arc<HotkeyState>) {
+    if state.listener_running.swap(true, Ordering::SeqCst) {
+        return; // already running
+    }
+
+    let state_clone = Arc::clone(state);
+    let running_flag = Arc::clone(state);
     let app_handle = app.clone();
 
     thread::spawn(move || {
@@ -67,9 +77,9 @@ pub fn start_listener(app: &AppHandle, hotkey_str: &str) -> Arc<HotkeyState> {
                 eprintln!("rdev listener error: {:?}", e);
             }
         }
-    });
 
-    state
+        running_flag.listener_running.store(false, Ordering::SeqCst);
+    });
 }
 
 fn check_combo(held_keys: &HashSet<Key>, state: &Arc<HotkeyState>, app: &AppHandle) {

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -54,7 +54,10 @@ pub fn ensure_listener(app: &AppHandle, state: &Arc<HotkeyState>) {
     thread::spawn(move || {
         let mut held_keys: HashSet<Key> = HashSet::new();
 
-        let handle_event = move |event_type: EventType| match event_type {
+        // `mut` is used by the rdev path below; on macOS the closure is moved
+        // into the event tap without being called through this binding.
+        #[cfg_attr(target_os = "macos", allow(unused_mut))]
+        let mut handle_event = move |event_type: EventType| match event_type {
             EventType::KeyPress(key) => {
                 held_keys.insert(key);
                 check_combo(&held_keys, &state_clone, &app_handle);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ mod history;
 mod hotkey;
 #[cfg(target_os = "macos")]
 mod macos_event_tap;
+#[cfg(target_os = "macos")]
+mod macos_microphone;
 mod llm;
 mod output;
 mod pipeline;
@@ -33,23 +35,43 @@ pub struct AppState {
 }
 
 // --- Audio commands ---
+//
+// These (and the whisper load/transcribe commands below) are async and run
+// their blocking work on the thread pool: synchronous Tauri commands execute
+// on the main thread, and blocking it while CoreAudio raises the microphone
+// permission prompt deadlocks the dialog (it re-presents forever). Heavy
+// whisper work would likewise freeze the UI.
 
 #[tauri::command]
-fn list_audio_devices() -> Result<Vec<audio::AudioDevice>, AppError> {
-    audio::list_input_devices()
+async fn list_audio_devices() -> Result<Vec<audio::AudioDevice>, AppError> {
+    tauri::async_runtime::spawn_blocking(audio::list_input_devices)
+        .await
+        .map_err(|e| AppError::Audio(format!("task join error: {e}")))?
 }
 
 #[tauri::command]
-fn start_recording(
-    state: tauri::State<'_, AppState>,
+async fn start_recording(
+    app: tauri::AppHandle,
     device_index: Option<usize>,
 ) -> Result<(), AppError> {
-    state.recorder.lock().unwrap().start_recording(device_index)
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let result = state.recorder.lock().unwrap().start_recording(device_index);
+        result
+    })
+    .await
+    .map_err(|e| AppError::Audio(format!("task join error: {e}")))?
 }
 
 #[tauri::command]
-fn stop_recording(state: tauri::State<'_, AppState>) -> Result<Vec<u8>, AppError> {
-    state.recorder.lock().unwrap().stop_recording()
+async fn stop_recording(app: tauri::AppHandle) -> Result<Vec<u8>, AppError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let result = state.recorder.lock().unwrap().stop_recording();
+        result
+    })
+    .await
+    .map_err(|e| AppError::Audio(format!("task join error: {e}")))?
 }
 
 // --- Whisper commands ---
@@ -65,20 +87,24 @@ async fn download_whisper_model(app: tauri::AppHandle, model_name: String) -> Re
 }
 
 #[tauri::command]
-fn load_whisper_model(
-    state: tauri::State<'_, AppState>,
-    model_name: String,
-) -> Result<(), AppError> {
-    state.whisper.load_model(&model_name)
+async fn load_whisper_model(app: tauri::AppHandle, model_name: String) -> Result<(), AppError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        state.whisper.load_model(&model_name)
+    })
+    .await
+    .map_err(|e| AppError::Whisper(format!("task join error: {e}")))?
 }
 
 #[tauri::command]
-fn transcribe_audio(
-    state: tauri::State<'_, AppState>,
-    wav_bytes: Vec<u8>,
-) -> Result<String, AppError> {
-    let language = state.settings.lock().unwrap().whisper_language.clone();
-    state.whisper.transcribe(&wav_bytes, &language)
+async fn transcribe_audio(app: tauri::AppHandle, wav_bytes: Vec<u8>) -> Result<String, AppError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let language = state.settings.lock().unwrap().whisper_language.clone();
+        state.whisper.transcribe(&wav_bytes, &language)
+    })
+    .await
+    .map_err(|e| AppError::Whisper(format!("task join error: {e}")))?
 }
 
 #[tauri::command]
@@ -176,6 +202,66 @@ fn open_accessibility_settings() {
     {
         let _ = std::process::Command::new("open")
             .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            .spawn();
+    }
+}
+
+/// Re-check Accessibility and (re)start the hotkey listener without a relaunch.
+/// Returns whether the permission is granted; the listener runs iff granted.
+#[tauri::command]
+fn restart_hotkey_listener(app: tauri::AppHandle) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if !macos_event_tap::has_accessibility_permission() {
+            return false;
+        }
+        let state = app.state::<AppState>();
+        hotkey::ensure_listener(&app, &state.hotkey_state);
+        true
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let state = app.state::<AppState>();
+        hotkey::ensure_listener(&app, &state.hotkey_state);
+        true
+    }
+}
+
+// On macOS, cpal touching CoreAudio implicitly triggers the microphone
+// permission prompt, so the UI checks/requests the permission explicitly
+// before listing devices or recording. On other platforms these report
+// "granted" (no-op).
+
+#[tauri::command]
+fn check_microphone_permission() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        macos_microphone::microphone_permission_status().to_string()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "granted".to_string()
+    }
+}
+
+#[tauri::command]
+async fn request_microphone_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos_microphone::request_microphone_permission().await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+#[tauri::command]
+fn open_microphone_settings() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
             .spawn();
     }
 }
@@ -303,25 +389,43 @@ pub fn run() {
                 }
             }
 
+            let hotkey_state = Arc::new(HotkeyState::new(hotkey::parse_hotkey_string(
+                &loaded_settings.hotkey,
+            )));
+
             // On macOS the global hotkey + auto-paste need Accessibility permission.
-            // If it's missing, trigger the system prompt and notify the UI (the
-            // Dashboard also re-checks on mount and shows a banner).
+            // Only start the listener when granted (a tap created without the grant
+            // is dead); the banner's "Re-check" restarts it via
+            // `restart_hotkey_listener` once the user grants access.
             #[cfg(target_os = "macos")]
             {
                 use tauri::Emitter;
-                if !macos_event_tap::has_accessibility_permission() {
+                if macos_event_tap::has_accessibility_permission() {
+                    hotkey::ensure_listener(app.handle(), &hotkey_state);
+                } else {
                     eprintln!(
                         "Accessibility permission not granted — the global hotkey and \
                          auto-paste will not work until it is granted in System Settings \
-                         ▸ Privacy & Security ▸ Accessibility, then the app is relaunched."
+                         ▸ Privacy & Security ▸ Accessibility."
                     );
-                    macos_event_tap::request_accessibility_permission();
+                    // Auto-fire the system prompt only on first launch; afterwards
+                    // the banner handles it (re-prompting is useless when the real
+                    // problem is a stale TCC entry from a previous unsigned build).
+                    let already_prompted = store
+                        .get("accessibility_prompt_shown")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if !already_prompted {
+                        macos_event_tap::request_accessibility_permission();
+                        store.set("accessibility_prompt_shown", true);
+                        let _ = store.save();
+                    }
                     let _ = app.handle().emit("permission-required", "accessibility");
                 }
             }
 
-            // Start the global hotkey listener
-            let hotkey_state = hotkey::start_listener(app.handle(), &loaded_settings.hotkey);
+            #[cfg(not(target_os = "macos"))]
+            hotkey::ensure_listener(app.handle(), &hotkey_state);
 
             app.manage(AppState {
                 recorder: Mutex::new(AudioRecorder::new()),
@@ -358,6 +462,10 @@ pub fn run() {
             check_accessibility_permission,
             request_accessibility_permission,
             open_accessibility_settings,
+            restart_hotkey_listener,
+            check_microphone_permission,
+            request_microphone_permission,
+            open_microphone_settings,
             get_settings,
             save_settings,
             reset_settings,

--- a/src-tauri/src/macos_event_tap.rs
+++ b/src-tauri/src/macos_event_tap.rs
@@ -194,11 +194,9 @@ where
         let tap_addr = tap as usize;
         thread::spawn(move || loop {
             thread::sleep(std::time::Duration::from_secs(1));
-            unsafe {
-                let tap = tap_addr as CFMachPortRef;
-                if !CGEventTapIsEnabled(tap) {
-                    CGEventTapEnable(tap, true);
-                }
+            let tap = tap_addr as CFMachPortRef;
+            if !CGEventTapIsEnabled(tap) {
+                CGEventTapEnable(tap, true);
             }
         });
 

--- a/src-tauri/src/macos_microphone.rs
+++ b/src-tauri/src/macos_microphone.rs
@@ -42,6 +42,12 @@ pub fn microphone_permission_status() -> &'static str {
 /// If permission was already decided, the completion handler fires
 /// immediately with the stored answer.
 pub async fn request_microphone_permission() -> bool {
+    // All ObjC values stay inside the sync helper: the returned future must be
+    // Send (Tauri requirement), and RcBlock is not.
+    spawn_request().await.unwrap_or(false)
+}
+
+fn spawn_request() -> tokio::sync::oneshot::Receiver<bool> {
     let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
     // The completion block is `Fn`, but the oneshot sender must be consumed.
     let tx = Mutex::new(Some(tx));
@@ -50,6 +56,8 @@ pub async fn request_microphone_permission() -> bool {
             let _ = tx.send(granted.as_bool());
         }
     });
+    // AVFoundation copies the (refcounted) block for the async callback, so
+    // dropping our reference when this fn returns is fine.
     unsafe {
         let _: () = msg_send![
             class!(AVCaptureDevice),
@@ -57,5 +65,5 @@ pub async fn request_microphone_permission() -> bool {
             completionHandler: &*block
         ];
     }
-    rx.await.unwrap_or(false)
+    rx
 }

--- a/src-tauri/src/macos_microphone.rs
+++ b/src-tauri/src/macos_microphone.rs
@@ -1,0 +1,61 @@
+//! Microphone (TCC) permission handling on macOS via AVCaptureDevice.
+//!
+//! cpal touching CoreAudio implicitly triggers the microphone permission
+//! prompt, so the UI must check/request the permission explicitly *before*
+//! enumerating or opening input devices. The request must run off the main
+//! thread: if the main run loop is blocked while the prompt is up, the dialog
+//! can never deliver its result and keeps re-presenting.
+
+use block2::RcBlock;
+use objc2::runtime::{AnyObject, Bool};
+use objc2::{class, msg_send};
+use std::sync::Mutex;
+
+#[link(name = "AVFoundation", kind = "framework")]
+extern "C" {
+    /// NSString* AVMediaTypeAudio
+    static AVMediaTypeAudio: *const AnyObject;
+}
+
+// AVAuthorizationStatus values.
+const AV_AUTHORIZATION_STATUS_NOT_DETERMINED: isize = 0;
+const AV_AUTHORIZATION_STATUS_RESTRICTED: isize = 1;
+const AV_AUTHORIZATION_STATUS_AUTHORIZED: isize = 3;
+
+/// Current microphone permission status. Never triggers the system prompt.
+pub fn microphone_permission_status() -> &'static str {
+    unsafe {
+        let status: isize = msg_send![
+            class!(AVCaptureDevice),
+            authorizationStatusForMediaType: AVMediaTypeAudio
+        ];
+        match status {
+            AV_AUTHORIZATION_STATUS_NOT_DETERMINED => "notdetermined",
+            AV_AUTHORIZATION_STATUS_RESTRICTED => "restricted",
+            AV_AUTHORIZATION_STATUS_AUTHORIZED => "granted",
+            _ => "denied",
+        }
+    }
+}
+
+/// Fire the system microphone prompt and resolve once the user answers.
+/// If permission was already decided, the completion handler fires
+/// immediately with the stored answer.
+pub async fn request_microphone_permission() -> bool {
+    let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+    // The completion block is `Fn`, but the oneshot sender must be consumed.
+    let tx = Mutex::new(Some(tx));
+    let block = RcBlock::new(move |granted: Bool| {
+        if let Some(tx) = tx.lock().unwrap().take() {
+            let _ = tx.send(granted.as_bool());
+        }
+    });
+    unsafe {
+        let _: () = msg_send![
+            class!(AVCaptureDevice),
+            requestAccessForMediaType: AVMediaTypeAudio,
+            completionHandler: &*block
+        ];
+    }
+    rx.await.unwrap_or(false)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
   checkAccessibilityPermission,
   requestAccessibilityPermission,
   openAccessibilitySettings,
+  restartHotkeyListener,
 } from "./lib/commands";
 
 const isOverlay =
@@ -47,6 +48,21 @@ function Dashboard() {
   useEffect(() => {
     checkAccessibilityPermission().then(setPermissionOk).catch(() => {});
   }, []);
+
+  // While the banner is up, poll so it dismisses itself (and the hotkey
+  // listener restarts) the moment the user flips the toggle in System
+  // Settings — no relaunch needed.
+  useEffect(() => {
+    if (permissionOk) return;
+    const id = setInterval(() => {
+      restartHotkeyListener()
+        .then((ok) => {
+          if (ok) setPermissionOk(true);
+        })
+        .catch(() => {});
+    }, 2000);
+    return () => clearInterval(id);
+  }, [permissionOk]);
 
   // The backend emits this when it detects the permission is missing at startup.
   const onPermissionRequired = useCallback(() => setPermissionOk(false), []);
@@ -83,7 +99,13 @@ function Dashboard() {
             <div className="bg-error/10 border border-error text-error text-sm rounded-lg px-4 py-3 space-y-2">
               <p>
                 Accessibility permission is required for the global hotkey and
-                auto-paste to work. Grant it below, then relaunch the app.
+                auto-paste to work.
+              </p>
+              <p>
+                If you recently updated the app, System Settings may show Speech
+                AI Tool already enabled — that entry is stale: remove it with the
+                &minus; button (or toggle it off and on), then re-add the app.
+                This banner disappears as soon as access is granted.
               </p>
               <div className="flex flex-wrap items-center gap-2">
                 <button
@@ -102,16 +124,10 @@ function Dashboard() {
                   Open Settings
                 </button>
                 <button
-                  onClick={() => relaunch()}
-                  className="px-3 py-1 bg-surface hover:bg-primary text-text text-xs rounded transition-colors"
-                >
-                  Relaunch
-                </button>
-                <button
                   onClick={() =>
-                    checkAccessibilityPermission().then(setPermissionOk).catch(() => {})
+                    restartHotkeyListener().then(setPermissionOk).catch(() => {})
                   }
-                  className="px-3 py-1 text-text-muted hover:text-text text-xs transition-colors"
+                  className="px-3 py-1 bg-surface hover:bg-primary text-text text-xs rounded transition-colors"
                 >
                   Re-check
                 </button>

--- a/src/components/AudioDeviceSelect.tsx
+++ b/src/components/AudioDeviceSelect.tsx
@@ -22,18 +22,28 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
   const [testResult, setTestResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const refreshPermission = useCallback(() => {
+    checkMicrophonePermission()
+      .then((p) => {
+        setMicPermission(p);
+        setError(null);
+      })
+      .catch((e) => setError(String(e)));
+  }, []);
+
   // Only touch the audio subsystem once the mic permission is granted —
   // device enumeration itself triggers the macOS permission prompt.
   useEffect(() => {
-    checkMicrophonePermission()
-      .then(setMicPermission)
-      .catch((e) => setError(String(e)));
-  }, []);
+    refreshPermission();
+  }, [refreshPermission]);
 
   useEffect(() => {
     if (micPermission !== "granted") return;
     listAudioDevices()
-      .then((devs) => setDevices(devs))
+      .then((devs) => {
+        setDevices(devs);
+        setError(null);
+      })
       .catch((e) => setError(String(e)));
   }, [micPermission]);
 
@@ -41,17 +51,11 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
     setError(null);
     try {
       await requestMicrophonePermission();
-      setMicPermission(await checkMicrophonePermission());
+      refreshPermission();
     } catch (e) {
       setError(String(e));
     }
-  }, []);
-
-  const recheckPermission = useCallback(() => {
-    checkMicrophonePermission()
-      .then(setMicPermission)
-      .catch((e) => setError(String(e)));
-  }, []);
+  }, [refreshPermission]);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const val = e.target.value === "" ? null : Number(e.target.value);
@@ -81,6 +85,16 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
       setRecording(false);
     }
   };
+
+  if (micPermission === "loading") {
+    return (
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-text-muted">Microphone</label>
+        <p className="text-text-muted text-sm">Checking microphone access…</p>
+        {error && <p className="text-error text-sm">{error}</p>}
+      </div>
+    );
+  }
 
   if (micPermission === "notdetermined") {
     return (
@@ -117,7 +131,7 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
             Open Settings
           </button>
           <button
-            onClick={recheckPermission}
+            onClick={refreshPermission}
             className="px-4 py-2 rounded text-sm font-medium text-text-muted hover:text-text transition-colors"
           >
             Re-check

--- a/src/components/AudioDeviceSelect.tsx
+++ b/src/components/AudioDeviceSelect.tsx
@@ -1,5 +1,13 @@
-import { useState, useEffect } from "react";
-import { listAudioDevices, startRecording, stopRecording } from "../lib/commands";
+import { useState, useEffect, useCallback } from "react";
+import {
+  listAudioDevices,
+  startRecording,
+  stopRecording,
+  checkMicrophonePermission,
+  requestMicrophonePermission,
+  openMicrophoneSettings,
+  type MicPermission,
+} from "../lib/commands";
 import type { AudioDevice } from "../lib/types";
 
 interface AudioDeviceSelectProps {
@@ -7,15 +15,41 @@ interface AudioDeviceSelectProps {
 }
 
 export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectProps) {
+  const [micPermission, setMicPermission] = useState<MicPermission | "loading">("loading");
   const [devices, setDevices] = useState<AudioDevice[]>([]);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [recording, setRecording] = useState(false);
   const [testResult, setTestResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Only touch the audio subsystem once the mic permission is granted —
+  // device enumeration itself triggers the macOS permission prompt.
   useEffect(() => {
+    checkMicrophonePermission()
+      .then(setMicPermission)
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  useEffect(() => {
+    if (micPermission !== "granted") return;
     listAudioDevices()
       .then((devs) => setDevices(devs))
+      .catch((e) => setError(String(e)));
+  }, [micPermission]);
+
+  const enableMicrophone = useCallback(async () => {
+    setError(null);
+    try {
+      await requestMicrophonePermission();
+      setMicPermission(await checkMicrophonePermission());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const recheckPermission = useCallback(() => {
+    checkMicrophonePermission()
+      .then(setMicPermission)
       .catch((e) => setError(String(e)));
   }, []);
 
@@ -48,6 +82,52 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
     }
   };
 
+  if (micPermission === "notdetermined") {
+    return (
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-text-muted">Microphone</label>
+        <p className="text-text-muted text-sm">
+          Microphone access is needed to record and transcribe your speech.
+        </p>
+        <button
+          onClick={enableMicrophone}
+          className="px-4 py-2 rounded text-sm font-medium bg-primary text-white hover:bg-blue-700 transition-colors"
+        >
+          Enable microphone access
+        </button>
+        {error && <p className="text-error text-sm">{error}</p>}
+      </div>
+    );
+  }
+
+  if (micPermission === "denied" || micPermission === "restricted") {
+    return (
+      <div className="space-y-3">
+        <label className="block text-sm font-medium text-text-muted">Microphone</label>
+        <p className="text-warning text-sm">
+          Microphone access is denied. Open System Settings ▸ Privacy &amp; Security ▸
+          Microphone and enable Speech AI Tool. After an app update you may need to
+          remove the stale entry (−) and re-enable it.
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => openMicrophoneSettings()}
+            className="px-4 py-2 rounded text-sm font-medium bg-primary text-white hover:bg-blue-700 transition-colors"
+          >
+            Open Settings
+          </button>
+          <button
+            onClick={recheckPermission}
+            className="px-4 py-2 rounded text-sm font-medium text-text-muted hover:text-text transition-colors"
+          >
+            Re-check
+          </button>
+        </div>
+        {error && <p className="text-error text-sm">{error}</p>}
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
       <label className="block text-sm font-medium text-text-muted">Microphone</label>
@@ -67,7 +147,8 @@ export default function AudioDeviceSelect({ onDeviceChange }: AudioDeviceSelectP
       <div className="flex items-center gap-3">
         <button
           onClick={toggleRecording}
-          className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+          disabled={micPermission !== "granted"}
+          className={`px-4 py-2 rounded text-sm font-medium transition-colors disabled:opacity-50 ${
             recording
               ? "bg-recording text-white hover:bg-red-600 animate-pulse"
               : "bg-primary text-white hover:bg-blue-700"

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -75,6 +75,28 @@ export async function openAccessibilitySettings(): Promise<void> {
   return invoke("open_accessibility_settings");
 }
 
+// Re-checks Accessibility and (re)starts the hotkey listener if granted, so
+// a fresh grant takes effect without relaunching the app.
+export async function restartHotkeyListener(): Promise<boolean> {
+  return invoke("restart_hotkey_listener");
+}
+
+// On macOS the microphone permission must be checked/requested explicitly
+// before touching audio devices; elsewhere the backend reports "granted".
+export type MicPermission = "notdetermined" | "restricted" | "denied" | "granted";
+
+export async function checkMicrophonePermission(): Promise<MicPermission> {
+  return invoke("check_microphone_permission");
+}
+
+export async function requestMicrophonePermission(): Promise<boolean> {
+  return invoke("request_microphone_permission");
+}
+
+export async function openMicrophoneSettings(): Promise<void> {
+  return invoke("open_microphone_settings");
+}
+
 export async function getSettings(): Promise<AppSettings> {
   return invoke("get_settings");
 }


### PR DESCRIPTION
## Problem

Two macOS bugs on the unsigned release DMG:

1. **Settings page mic prompt loops forever** (accept or deny) until force quit. `list_audio_devices` was a synchronous Tauri command — sync commands run on the **main thread** in Tauri v2. cpal's CoreAudio enumeration triggers the microphone TCC prompt, and the blocked main run loop can never deliver the dialog's result, so it re-presents indefinitely.
2. **Main page claims Accessibility permission is missing even when granted.** Unsigned/ad-hoc builds get a new code-directory hash each release, so the TCC grant recorded for a previous build no longer matches (`AXIsProcessTrusted()` returns false while System Settings shows a checked, stale entry). On top of that, the hotkey listener thread died permanently if the event tap failed to create, so even after granting, a relaunch was required.

## Changes

- **Async + `spawn_blocking`** for `list_audio_devices`, `start_recording`, `stop_recording`, `load_whisper_model`, `transcribe_audio` — the main thread stays free to service TCC prompts (and heavy whisper work no longer freezes the UI).
- **Explicit mic permission handling** (`src-tauri/src/macos_microphone.rs`, AVCaptureDevice via `objc2`/`block2`): new `check_microphone_permission`, `request_microphone_permission`, `open_microphone_settings` commands. `AudioDeviceSelect` now gates device enumeration on the permission state: *not determined* → "Enable microphone access" button; *denied/restricted* → guidance + settings deep-link; *granted* → existing UI.
- **Restartable hotkey listener** (`hotkey::ensure_listener`): started only when Accessibility is granted; if the tap fails, the running flag clears so it can be retried. New `restart_hotkey_listener` command; the banner polls it every 2s, so the hotkey starts working (and the banner dismisses) the moment the user flips the toggle — no relaunch.
- **First-launch-only auto-prompt** for Accessibility (flag stored as a separate key in the settings store), and banner copy that explains the stale-entry situation after unsigned app updates (remove with − and re-add).

## Testing

- `pnpm build` (tsc + vite) passes locally.
- No Rust toolchain on my dev box — CI's `macos-latest` job is the compile gate for the objc2/AVFoundation code; ubuntu/windows jobs cover the non-macOS stubs.
- Behavior verification on a Mac (after CI): `tccutil reset Microphone com.speech-ai-tool.app && tccutil reset Accessibility com.speech-ai-tool.app`, then confirm Settings no longer auto-prompts, the mic prompt appears once from the explicit button with a responsive window, and granting Accessibility clears the banner + activates the hotkey without relaunch.

Note: `Cargo.lock` will pick up the two direct-dependency entries (`objc2`, `block2` — already in-tree transitively) on the first `cargo` run; no version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)