### PR TITLE
chore: bump version to v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "speech-ai-tool",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@10.28.1",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "speech-ai-tool"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytemuck",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speech-ai-tool"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicklasxyz/tauri-v2-schema/refs/heads/main/tauri.conf.json",
   "productName": "Speech AI Tool",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "com.speech-ai-tool.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump for the v0.3.4 release (macOS permission fixes from #13). The version-bump workflow can't push to main directly due to branch protection, so bumping via PR; I'll tag `v0.3.4` after merge to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)